### PR TITLE
ENH: updated encoder and decoder for beta-vae

### DIFF
--- a/disvae/decoder.py
+++ b/disvae/decoder.py
@@ -21,46 +21,59 @@ class DecoderBetaB(nn.Module):
         device : torch.device
             Device on which to run the code.
 
-        Refernces:
+        Model Architecture (transposed for decoder)
+        ------------
+        - 4 convolutional layers (each with 32 channels), (4 x 4 kernel), (stride of 2)
+        - 2 fully connected layers (each of 256 units)
+        - Latent distribution:
+            - 1 fully connected layer of 20 units (log variance and mean for 10 Gaussians)
+
+        References:
             [1] Burgess, Christopher P., et al. "Understanding disentangling in
             $\beta$-VAE." arXiv preprint arXiv:1804.03599 (2018).
         """
         super(DecoderBetaB, self).__init__()
 
+        # Layer parameters
         hid_channels = 32
         kernel_size = 4
         hidden_dim = 256
         self.img_size = img_size
         # Shape required to start transpose convs
-        self.reshape = (hid_channels * 2, kernel_size, kernel_size)
+        self.reshape = (hid_channels, kernel_size, kernel_size)
         n_chan = self.img_size[0]
-
         self.img_size = img_size
 
+        # Fully connected layers
         self.lin1 = nn.Linear(latent_dim, hidden_dim)
-        self.lin2 = nn.Linear(hidden_dim, np.product(self.reshape))
+        self.lin2 = nn.Linear(hidden_dim, hidden_dim)
+        self.lin3 = nn.Linear(hidden_dim, np.product(self.reshape))
 
+        # Convolutional layers
         cnn_kwargs = dict(stride=2, padding=1)
+        # If input image is 64x64 do fourth convolution
         if self.img_size[1:] == (64, 64):
-            self.convT_64 = nn.Conv2d(hid_channels * 2, hid_channels * 2, kernel_size,
-                                      **cnn_kwargs)
+            self.convT_64 = nn.ConvTranspose2d(hid_channels, hid_channels, kernel_size, **cnn_kwargs)
 
-        cnn_kwargs = dict(stride=2, padding=1)
-        self.convT1 = nn.ConvTranspose2d(hid_channels * 2, hid_channels, kernel_size, **cnn_kwargs)
+        self.convT1 = nn.ConvTranspose2d(hid_channels, hid_channels, kernel_size, **cnn_kwargs)
         self.convT2 = nn.ConvTranspose2d(hid_channels, hid_channels, kernel_size, **cnn_kwargs)
         self.convT3 = nn.ConvTranspose2d(hid_channels, n_chan, kernel_size, **cnn_kwargs)
 
     def forward(self, z):
         batch_size = z.size(0)
 
+        # Fully connected layers with ReLu activations
         x = torch.relu(self.lin1(z))
         x = torch.relu(self.lin2(x))
+        x = torch.relu(self.lin3(x))
         x = x.view(batch_size, *self.reshape)
 
+        # Convolutional layers with ReLu activations
         if self.img_size[1:] == (64, 64):
             x = torch.relu(self.convT_64(x))
         x = torch.relu(self.convT1(x))
         x = torch.relu(self.convT2(x))
+        # Sigmoid activation for final conv layer
         x = torch.sigmoid(self.convT3(x))
 
         return x

--- a/disvae/encoder.py
+++ b/disvae/encoder.py
@@ -21,47 +21,64 @@ class EncoderBetaB(nn.Module):
         device : torch.device
             Device on which to run the code.
 
-        Refernces:
+        Model Architecture (transposed for decoder)
+        ------------
+        - 4 convolutional layers (each with 32 channels), (4 x 4 kernel), (stride of 2)
+        - 2 fully connected layers (each of 256 units)
+        - Latent distribution:
+            - 1 fully connected layer of 20 units (log variance and mean for 10 Gaussians)
+
+        References:
             [1] Burgess, Christopher P., et al. "Understanding disentangling in
             $\beta$-VAE." arXiv preprint arXiv:1804.03599 (2018).
         """
         super(EncoderBetaB, self).__init__()
 
+        # Layer parameters
         hid_channels = 32
         kernel_size = 4
         hidden_dim = 256
         self.img_size = img_size
         # Shape required to start transpose convs
-        self.reshape = (hid_channels * 2, kernel_size, kernel_size)
+        self.reshape = (hid_channels, kernel_size, kernel_size)
         n_chan = self.img_size[0]
-
         self.img_size = img_size
 
+        # Convolutional layers
         cnn_kwargs = dict(stride=2, padding=1)
         self.conv1 = nn.Conv2d(n_chan, hid_channels, kernel_size, **cnn_kwargs)
-        self.conv2 = nn.Conv2d(hid_channels, hid_channels * 2, kernel_size, **cnn_kwargs)
-        self.conv3 = nn.Conv2d(hid_channels * 2, hid_channels * 2, kernel_size, **cnn_kwargs)
+        self.conv2 = nn.Conv2d(hid_channels, hid_channels, kernel_size, **cnn_kwargs)
+        self.conv3 = nn.Conv2d(hid_channels, hid_channels, kernel_size, **cnn_kwargs)
+
+        # If input image is 64x64 do fourth convolution
         if self.img_size[1:] == (64, 64):
             self.conv_64 = nn.Conv2d(hid_channels, hid_channels, kernel_size, **cnn_kwargs)
 
+        # Fully connected layers
         self.lin1 = nn.Linear(np.product(self.reshape), hidden_dim)
+        self.lin2 = nn.Linear(hidden_dim, hidden_dim)
 
+        # Fully connected layers for mean and variance
         self.mu_gen = nn.Linear(hidden_dim, latent_dim)
         self.log_var_gen = nn.Linear(hidden_dim, latent_dim)
 
     def forward(self, x):
         batch_size = x.size(0)
 
+        # Convolutional layers with ReLu activations
         x = torch.relu(self.conv1(x))
-        if self.img_size[1:] == (64, 64):
-            x = torch.relu(self.conv_64(x))
         x = torch.relu(self.conv2(x))
         x = torch.relu(self.conv3(x))
+        if self.img_size[1:] == (64, 64):
+            x = torch.relu(self.conv_64(x))
 
+        # Fully connected layers with ReLu activations
         x = x.view((batch_size, -1))
         x = torch.relu(self.lin1(x))
+        x = torch.relu(self.lin2(x))
 
+        # Fully connected layer for log variance and mean
         mu = self.mu_gen(x)
-        log_var = self.log_var_gen(x)
+        log_var = self.log_var_gen(x)  #Log std-dev in paper (bear in mind)
 
         return mu, log_var


### PR DESCRIPTION
Updated the model architecture according to reference [1] section A1

[1] Burgess, Christopher P., et al. "Understanding disentangling in
            $\beta$-VAE." arXiv preprint arXiv:1804.03599 (2018).

Updated Model Architecture for Encoder (transposed for decoder)
------------
- 4 convolutional layers (each with 32 channels), (4 x 4 kernel), (stride of 2)
- 2 fully connected layers (each of 256 units)
- Latent distribution:
  - 1 fully connected layer of 20 units (log variance and mean for 10 Gaussians)